### PR TITLE
Updated dependencies to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,12 @@
     <properties>
         <version.jdk>1.8</version.jdk>
         <version.junit>4.12</version.junit>
-        <version.jbehave>4.3.5</version.jbehave>
-        <version.slf4j>1.7.26</version.slf4j>
+        <version.jbehave>4.6</version.jbehave>
+        <version.slf4j>1.7.28</version.slf4j>
         <version.groovy>2.5.7</version.groovy>
         <version.spock>1.3-groovy-2.5</version.spock>
-        <version.cglib>3.2.12</version.cglib>
-        <version.lombok>1.18.8</version.lombok>
+        <version.cglib>3.3.0</version.cglib>
+        <version.lombok>1.18.10</version.lombok>
         <version.logback>1.2.3</version.logback>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/jbehavesupport/runner/reporter/JUnitStepReporter.java
+++ b/src/main/java/org/jbehavesupport/runner/reporter/JUnitStepReporter.java
@@ -93,6 +93,13 @@ public class JUnitStepReporter extends AbstractJUnitReporter {
         }
     }
 
+    private Description getStepDescriptionByName(String step) {
+        return getAllChildren(currentScenarioDescription.getChildren(), new ArrayList<>()).stream()
+            .filter(description -> description.getDisplayName().startsWith(step))
+            .findAny()
+            .orElse(currentStepDescription);
+    }
+
     @Override
     public void afterStory(boolean givenOrRestartingStory) {
         super.afterStory(givenOrRestartingStory);
@@ -167,7 +174,11 @@ public class JUnitStepReporter extends AbstractJUnitReporter {
     public void successful(String step) {
         super.successful(step);
         if (notAGivenStory()) {
-            notifier.fireTestFinished(currentStepDescription);
+            if (currentStepDescription.getDisplayName().startsWith(step)) {
+                notifier.fireTestFinished(currentStepDescription);
+            } else {
+                notifier.fireTestFinished(getStepDescriptionByName(step));
+            }
         }
     }
 

--- a/src/test/groovy/org/jbehavesupport/runner/CompositeStepStoriesTest.groovy
+++ b/src/test/groovy/org/jbehavesupport/runner/CompositeStepStoriesTest.groovy
@@ -30,8 +30,6 @@ import spock.util.environment.RestoreSystemProperties
 class CompositeStepStoriesTest extends Specification {
 
     def notifier = Mock(RunNotifier)
-    // JUnitStepReporter:170 - wrong value currentStepDescription - any reason why its taken from iterator
-    // and not from the list based on the step name?
 
     def "Test correct notifications"() {
         given:

--- a/src/test/groovy/org/jbehavesupport/runner/CompositeStepStoriesTest.groovy
+++ b/src/test/groovy/org/jbehavesupport/runner/CompositeStepStoriesTest.groovy
@@ -30,6 +30,8 @@ import spock.util.environment.RestoreSystemProperties
 class CompositeStepStoriesTest extends Specification {
 
     def notifier = Mock(RunNotifier)
+    // JUnitStepReporter:170 - wrong value currentStepDescription - any reason why its taken from iterator
+    // and not from the list based on the step name?
 
     def "Test correct notifications"() {
         given:
@@ -52,8 +54,6 @@ class CompositeStepStoriesTest extends Specification {
         then:
         1 * notifier.fireTestStarted({it.displayName.contains("When Sign up with audit")} as Description)
         then:
-        1 * notifier.fireTestFinished({it.displayName.contains("When Sign up with audit")} as Description)
-        then:
         1 * notifier.fireTestStarted({it.displayName.contains("When Sign up user")} as Description)
         then:
         1 * notifier.fireTestFinished({it.displayName.contains("When Sign up user")} as Description)
@@ -61,6 +61,8 @@ class CompositeStepStoriesTest extends Specification {
         1 * notifier.fireTestStarted({it.displayName.contains("When Auditing user")} as Description)
         then:
         1 * notifier.fireTestFinished({it.displayName.contains("When Auditing user")} as Description)
+        then:
+        1 * notifier.fireTestFinished({it.displayName.contains("When Sign up with audit")} as Description)
         then:
         1 * notifier.fireTestFinished({it.displayName.equals("Scenario: Composite step")} as Description)
         then:

--- a/src/test/groovy/org/jbehavesupport/runner/FailedStepStoriesTest.groovy
+++ b/src/test/groovy/org/jbehavesupport/runner/FailedStepStoriesTest.groovy
@@ -51,8 +51,6 @@ class FailedStepStoriesTest extends Specification {
         then:
         1 * notifier.fireTestStarted({it.displayName.contains("When Sign up with audit")} as Description)
         then:
-        1 * notifier.fireTestFinished({it.displayName.contains("When Sign up with audit")} as Description)
-        then:
         1 * notifier.fireTestStarted({it.displayName.contains("When Sign up user")} as Description)
         then:
         1 * notifier.fireTestFinished({it.displayName.contains("When Sign up user")} as Description)
@@ -60,6 +58,8 @@ class FailedStepStoriesTest extends Specification {
         1 * notifier.fireTestStarted({it.displayName.contains("When Auditing user")} as Description)
         then:
         1 * notifier.fireTestFinished({it.displayName.contains("When Auditing user")} as Description)
+        then:
+        1 * notifier.fireTestFinished({it.displayName.contains("When Sign up with audit")} as Description)
         then:
         1 * notifier.fireTestStarted({it.displayName.contains("Then Failed step")} as Description)
         then:


### PR DESCRIPTION
Right now not working due to change in jbehave composite handling, before was:
composite start
**composite end**
partial1 start
partial1 end
partial2 start
partial2 end

Right now:
composite start
partial1 start
partial1 end
partial2 start
partial2 end
**composite end**

And I cant seem to be able to correctly fix the failed tests because of that... @mbocek Can we talk when you have some time?

Btw. in the pom there is a <version.groovy>2.5.7</version.groovy> property which is not used anywhere (groovy comes from spock atm.) - should it be deleted or should the groovy version be added explicitly?