### PR TITLE
Upgrade to JBehave 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ public class BasicStory extends JUnit5Story {
 ```
 
 ### JUnit 4
+To use JUnit4 runner please add a dependency for `junit` or `junit-vintage-engine` to your project explicitly.
 Very simple java class with runner implementation:
 ```java
 @RunWith(JUnitRunner.class)
@@ -72,10 +73,11 @@ In the IDE reporting is shown:
 
 ## Compatibility matrix
 | jbehave-junit-support | jbehave  |
-|---------------------- | --------:|
+|-----------------------| --------:|
 | 1.0.1                 | 4.0.5    |
 | 1.2.7                 | 4.1.3    |
 | 4.3.5                 | 4.3.5    |
 | 4.6.1                 | 4.6.1    |
 | 4.8.0                 | 4.8      |
 | 4.8.3                 | 4.8.3    |
+| 5.0.0                 | 5.0      |

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,10 @@
 
     <properties>
         <version.jdk>1.8</version.jdk>
-        <version.junit>5.7.1</version.junit>
-        <version.junit-platform>1.7.1</version.junit-platform>
-        <version.jbehave>4.8.3</version.jbehave>
+        <version.junit>5.8.2</version.junit>
+        <version.junit-platform>1.8.2</version.junit-platform>
+        <version.junit4>4.13.2</version.junit4>
+        <version.jbehave>5.0</version.jbehave>
         <version.slf4j>1.7.30</version.slf4j>
         <version.groovy>2.5.14</version.groovy>
         <version.spock>1.3-groovy-2.5</version.spock>
@@ -104,6 +105,13 @@
             <artifactId>junit-vintage-engine</artifactId>
             <version>${version.junit}</version>
             <scope>test</scope>
+        </dependency>
+        <!-- we need the explicit dependency since jbehave now does not bring it anymore and we use the code for runner -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit4}</version>
+            <scope>optional</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>

--- a/src/main/java/org/jbehavesupport/engine/JUnit5Stories.java
+++ b/src/main/java/org/jbehavesupport/engine/JUnit5Stories.java
@@ -37,7 +37,6 @@ public abstract class JUnit5Stories extends ConfigurableEmbedder {
         try {
             embedder.runStoriesAsPaths(storyPaths());
         } finally {
-            embedder.generateCrossReference();
             embedder.generateSurefireReport();
         }
     }

--- a/src/main/java/org/jbehavesupport/engine/executor/JBehaveExecutor.java
+++ b/src/main/java/org/jbehavesupport/engine/executor/JBehaveExecutor.java
@@ -62,7 +62,6 @@ public class JBehaveExecutor {
             engineExecutionListener.executionFinished(testDescriptor, TestExecutionResult.failed(e));
             throw new RuntimeException(e);
         } finally {
-            configuredEmbedder.generateCrossReference();
             configuredEmbedder.generateSurefireReport();
         }
     }

--- a/src/main/java/org/jbehavesupport/engine/reporter/AbstractLoggingReporter.java
+++ b/src/main/java/org/jbehavesupport/engine/reporter/AbstractLoggingReporter.java
@@ -18,7 +18,6 @@
  */
 package org.jbehavesupport.engine.reporter;
 
-import org.jbehave.core.model.Story;
 import org.junit.platform.engine.TestDescriptor;
 
 import static org.jbehavesupport.runner.JUnitRunnerFormatter.buildStoryText;
@@ -30,11 +29,11 @@ public class AbstractLoggingReporter extends LoggingReporter {
 
     protected int givenStories = 0;
 
-    protected boolean isEligibleAs(Story story, TestDescriptor testDescriptor, String storyName) {
-        return story.getName().equals(storyName) && testDescriptor.getDisplayName().startsWith(storyName);
+    protected boolean testIsEligibleAs(TestDescriptor testDescriptor, String storyName) {
+        return testDescriptor.getDisplayName().startsWith(storyName);
     }
 
-    protected boolean isEligibleAs(TestDescriptor testDescriptor, String storyName) {
+    protected boolean containerIsEligibleAs(TestDescriptor testDescriptor, String storyName) {
         return removeClass(testDescriptor.getDisplayName()).equals(buildStoryText(storyName));
     }
 

--- a/src/main/java/org/jbehavesupport/engine/reporter/JUnitStepReporter.java
+++ b/src/main/java/org/jbehavesupport/engine/reporter/JUnitStepReporter.java
@@ -20,7 +20,10 @@ package org.jbehavesupport.engine.reporter;
 
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.failures.UUIDExceptionWrapper;
+import org.jbehave.core.model.Scenario;
+import org.jbehave.core.model.Step;
 import org.jbehave.core.model.Story;
+import org.jbehave.core.steps.Timing;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
@@ -101,13 +104,13 @@ public class JUnitStepReporter extends AbstractJUnitReporter {
     }
 
     @Override
-    public void beforeScenario(String scenarioTitle) {
+    public void beforeScenario(Scenario scenario) {
         if (notAGivenStory()) {
             currentScenarioDescription = scenariosDescriptions.next();
             stepsDescriptions = getAllChildren(currentScenarioDescription.getChildren(), new ArrayList<>()).iterator();
             examplesDescriptions = getAllExamples(currentScenarioDescription.getChildren()).iterator();
             notifier.fireTestStarted(currentScenarioDescription);
-            super.beforeScenario(scenarioTitle);
+            super.beforeScenario(scenario);
         }
     }
 
@@ -140,15 +143,15 @@ public class JUnitStepReporter extends AbstractJUnitReporter {
     }
 
     @Override
-    public void afterScenario() {
-        super.afterScenario();
+    public void afterScenario(Timing timing) {
+        super.afterScenario(timing);
         if (notAGivenStory()) {
             notifier.fireTestFinished(currentScenarioDescription);
         }
     }
 
     @Override
-    public void beforeStep(String step) {
+    public void beforeStep(Step step) {
         if (notAGivenStory()) {
             currentStepDescription.push(stepsDescriptions.next());
             notifier.fireTestStarted(currentStepDescription.peek());
@@ -195,7 +198,7 @@ public class JUnitStepReporter extends AbstractJUnitReporter {
     }
 
     @Override
-    public void example(Map<String, String> tableRow) {
+    public void example(Map<String, String> tableRow, int exampleIndex) {
         if (notAGivenStory()) {
             if (nonNull(currentExampleDescription)) {
                 notifier.fireTestFinished(currentExampleDescription);
@@ -203,7 +206,7 @@ public class JUnitStepReporter extends AbstractJUnitReporter {
             currentExampleDescription = examplesDescriptions.next();
             notifier.fireTestStarted(currentExampleDescription);
         }
-        super.example(tableRow);
+        super.example(tableRow, exampleIndex);
     }
 
     @Override

--- a/src/main/java/org/jbehavesupport/engine/reporter/LoggingReporter.java
+++ b/src/main/java/org/jbehavesupport/engine/reporter/LoggingReporter.java
@@ -25,20 +25,22 @@ import lombok.extern.slf4j.Slf4j;
 import org.jbehave.core.model.ExamplesTable;
 import org.jbehave.core.model.GivenStories;
 import org.jbehave.core.model.Lifecycle;
-import org.jbehave.core.model.Meta;
 import org.jbehave.core.model.Narrative;
 import org.jbehave.core.model.OutcomesTable;
 import org.jbehave.core.model.Scenario;
+import org.jbehave.core.model.Step;
 import org.jbehave.core.model.Story;
 import org.jbehave.core.model.StoryDuration;
 import org.jbehave.core.reporters.NullStoryReporter;
+import org.jbehave.core.steps.StepCollector;
+import org.jbehave.core.steps.Timing;
 
 @Slf4j
 public class LoggingReporter extends NullStoryReporter {
 
     @Override
-    public void storyNotAllowed(Story story, String filter) {
-        log.info("Story: {} not allowed for filter: {}", story.getName(), filter);
+    public void storyExcluded(Story story, String filter) {
+        log.info("Story: {} excluded by filter: {}", story.getName(), filter);
     }
 
     @Override
@@ -76,30 +78,25 @@ public class LoggingReporter extends NullStoryReporter {
     }
 
     @Override
-    public void lifecyle(Lifecycle lifecycle) {
+    public void lifecycle(Lifecycle lifecycle) {
         if (!lifecycle.isEmpty()) {
             log.info("Lifecycle: {}", lifecycle);
         }
     }
 
     @Override
-    public void scenarioNotAllowed(Scenario scenario, String filter) {
-        log.info("Scenario: {} not allowed by filer: {}", scenario.getTitle(), filter);
+    public void scenarioExcluded(Scenario scenario, String filter) {
+        log.info("Scenario: {} excluded by filer: {}", scenario.getTitle(), filter);
     }
 
     @Override
-    public void beforeScenario(String scenarioTitle) {
-        log.info("Before scenario: {}", scenarioTitle);
+    public void beforeScenario(Scenario scenario) {
+        log.info("Before scenario: {}", scenario.getTitle());
     }
 
     @Override
-    public void scenarioMeta(Meta meta) {
-        log.info("Scenario meta: {}", meta);
-    }
-
-    @Override
-    public void afterScenario() {
-        log.info("After scenario");
+    public void afterScenario(Timing timing) {
+        log.info("After scenario, timing: {}", timing);
     }
 
     @Override
@@ -118,8 +115,8 @@ public class LoggingReporter extends NullStoryReporter {
     }
 
     @Override
-    public void example(Map<String, String> tableRow) {
-        log.info("Example: {}", tableRow);
+    public void example(Map<String, String> tableRow, int exampleIndex) {
+        log.info("Example: {}, index: {}", tableRow, exampleIndex);
     }
 
     @Override
@@ -128,8 +125,8 @@ public class LoggingReporter extends NullStoryReporter {
     }
 
     @Override
-    public void beforeStep(String step) {
-        log.info("Before step: {}", step);
+    public void beforeStep(Step step) {
+        log.info("Before step: {}", step.getStepAsString());
     }
 
     @Override
@@ -180,5 +177,25 @@ public class LoggingReporter extends NullStoryReporter {
     @Override
     public void pendingMethods(List<String> methods) {
         log.error("Pending methods: {}", methods);
+    }
+
+    @Override
+    public void beforeStoriesSteps(StepCollector.Stage stage) {
+        log.info("Before stories steps, stage: {}", stage);
+    }
+
+    @Override
+    public void afterStoriesSteps(StepCollector.Stage stage) {
+        log.info("After stories steps, stage: {}", stage);
+    }
+
+    @Override
+    public void beforeStorySteps(StepCollector.Stage stage, Lifecycle.ExecutionType type) {
+        log.info("Before story steps, stage: {}, type: {}", stage, type);
+    }
+
+    @Override
+    public void afterStorySteps(StepCollector.Stage stage, Lifecycle.ExecutionType type) {
+        log.info("After story steps, stage: {}, type: {}", stage, type);
     }
 }

--- a/src/main/java/org/jbehavesupport/engine/reporter/StoryLoggingReporter.java
+++ b/src/main/java/org/jbehavesupport/engine/reporter/StoryLoggingReporter.java
@@ -50,7 +50,7 @@ public class StoryLoggingReporter extends AbstractLoggingReporter {
         } else {
             for (TestDescriptor descriptor : rootDescriptor.getChildren()) {
                 if (descriptor.isTest()
-                    && isEligibleAs(descriptor, story.getName())) {
+                    && containerIsEligibleAs(descriptor, story.getName())) {
                     currentStoryDescriptor = descriptor;
                     engineExecutionListener.executionStarted(currentStoryDescriptor);
                 }

--- a/src/main/java/org/jbehavesupport/runner/reporter/AbstractJUnitReporter.java
+++ b/src/main/java/org/jbehavesupport/runner/reporter/AbstractJUnitReporter.java
@@ -34,11 +34,11 @@ public class AbstractJUnitReporter extends LoggingReporter {
 
     protected int givenStories = 0;
 
-    protected boolean isEligibleAs(Story story, Description description, String storyName) {
-        return story.getName().equals(storyName) && description.getDisplayName().startsWith(storyName);
+    protected boolean testIsEligibleAs(Description description, String storyName) {
+        return description.getDisplayName().startsWith(storyName);
     }
 
-    protected boolean isEligibleAs(Description description, String storyName) {
+    protected boolean suiteIsEligibleAs(Description description, String storyName) {
         return removeClass(description.getDisplayName()).equals(buildStoryText(storyName));
     }
 

--- a/src/main/java/org/jbehavesupport/runner/reporter/JUnitStoryReporter.java
+++ b/src/main/java/org/jbehavesupport/runner/reporter/JUnitStoryReporter.java
@@ -53,7 +53,7 @@ public class JUnitStoryReporter extends AbstractJUnitReporter {
         } else {
             for (Description description : rootDescription.getChildren()) {
                 if (description.isTest()
-                    && isEligibleAs(description, story.getName())) {
+                    && suiteIsEligibleAs(description, story.getName())) {
                     currentStoryDescription = description;
                     notifier.fireTestStarted(currentStoryDescription);
                 }

--- a/src/main/java/org/jbehavesupport/runner/reporter/LoggingReporter.java
+++ b/src/main/java/org/jbehavesupport/runner/reporter/LoggingReporter.java
@@ -25,13 +25,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.jbehave.core.model.ExamplesTable;
 import org.jbehave.core.model.GivenStories;
 import org.jbehave.core.model.Lifecycle;
-import org.jbehave.core.model.Meta;
 import org.jbehave.core.model.Narrative;
 import org.jbehave.core.model.OutcomesTable;
 import org.jbehave.core.model.Scenario;
+import org.jbehave.core.model.Step;
 import org.jbehave.core.model.Story;
 import org.jbehave.core.model.StoryDuration;
 import org.jbehave.core.reporters.NullStoryReporter;
+import org.jbehave.core.steps.Timing;
 
 /**
  * @author Michal Bocek
@@ -41,8 +42,8 @@ import org.jbehave.core.reporters.NullStoryReporter;
 public class LoggingReporter extends NullStoryReporter {
 
     @Override
-    public void storyNotAllowed(Story story, String filter) {
-        log.info("Story: {} not allowed for filter: {}", story.getName(), filter);
+    public void storyExcluded(Story story, String filter) {
+        log.info("Story: {} excluded by filter: {}", story.getName(), filter);
     }
 
     @Override
@@ -80,30 +81,25 @@ public class LoggingReporter extends NullStoryReporter {
     }
 
     @Override
-    public void lifecyle(Lifecycle lifecycle) {
+    public void lifecycle(Lifecycle lifecycle) {
         if (!lifecycle.isEmpty()) {
             log.info("Lifecycle: {}", lifecycle);
         }
     }
 
     @Override
-    public void scenarioNotAllowed(Scenario scenario, String filter) {
-        log.info("Scenario: {} not allowed by filer: {}", scenario.getTitle(), filter);
+    public void scenarioExcluded(Scenario scenario, String filter) {
+        log.info("Scenario: {} excluded by filer: {}", scenario.getTitle(), filter);
     }
 
     @Override
-    public void beforeScenario(String scenarioTitle) {
-        log.info("Before scenario: {}", scenarioTitle);
+    public void beforeScenario(Scenario scenario) {
+        log.info("Before scenario: {}", scenario.getTitle());
     }
 
     @Override
-    public void scenarioMeta(Meta meta) {
-        log.info("Scenario meta: {}", meta);
-    }
-
-    @Override
-    public void afterScenario() {
-        log.info("After scenario");
+    public void afterScenario(Timing timing) {
+        log.info("After scenario, timing: {}", timing);
     }
 
     @Override
@@ -122,8 +118,8 @@ public class LoggingReporter extends NullStoryReporter {
     }
 
     @Override
-    public void example(Map<String, String> tableRow) {
-        log.info("Example: {}", tableRow);
+    public void example(Map<String, String> tableRow, int exampleIndex) {
+        log.info("Example: {}, index: {}", tableRow, exampleIndex);
     }
 
     @Override
@@ -132,8 +128,8 @@ public class LoggingReporter extends NullStoryReporter {
     }
 
     @Override
-    public void beforeStep(String step) {
-        log.info("Before step: {}", step);
+    public void beforeStep(Step step) {
+        log.info("Before step: {}", step.getStepAsString());
     }
 
     @Override

--- a/src/test/java/org/jbehavesupport/engine/story/AndStepStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/AndStepStories.java
@@ -31,7 +31,7 @@ public class AndStepStories extends AbstractStories {
     }
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/AndStep.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/CommentStepStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/CommentStepStories.java
@@ -31,7 +31,7 @@ public class CommentStepStories extends AbstractStories {
     }
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/CommentStep.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/CompositeStepStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/CompositeStepStories.java
@@ -31,7 +31,7 @@ public class CompositeStepStories extends AbstractStories {
     }
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/CompositeStep.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/ExamplesStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/ExamplesStories.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class ExamplesStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/Examples.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/FailInGivenStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/FailInGivenStories.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class FailInGivenStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/FailInGivenStory.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/FailedStepStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/FailedStepStories.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class FailedStepStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/FailedStep.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/GivenStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/GivenStories.java
@@ -8,7 +8,7 @@ import java.util.List;
 public class GivenStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/GivenStory.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/GivenStoryBeforeScenarioStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/GivenStoryBeforeScenarioStories.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class GivenStoryBeforeScenarioStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/GivenStoryBeforeScenario.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/MultipleStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/MultipleStories.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class MultipleStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Arrays.asList(
             "org/jbehavesupport/runner/story/multipleScenario/Scenario01.story",
             "org/jbehavesupport/runner/story/multipleScenario/Scenario01-1.story",

--- a/src/test/java/org/jbehavesupport/engine/story/NestedGivenStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/NestedGivenStories.java
@@ -27,7 +27,7 @@ import org.jbehavesupport.runner.story.steps.TestSteps;
 public class NestedGivenStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/NestedGivenStory.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/PendingStepStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/PendingStepStories.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class PendingStepStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/PendingStep.story"
         );

--- a/src/test/java/org/jbehavesupport/engine/story/TwoGivenStoryBeforeScenarioStories.java
+++ b/src/test/java/org/jbehavesupport/engine/story/TwoGivenStoryBeforeScenarioStories.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class TwoGivenStoryBeforeScenarioStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Arrays.asList(
             "org/jbehavesupport/runner/story/GivenStoryBeforeScenario.story",
             "org/jbehavesupport/runner/story/SecondGivenStoryBeforeScenario.story"

--- a/src/test/java/org/jbehavesupport/runner/story/AndStepStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/AndStepStories.java
@@ -38,7 +38,7 @@ public class AndStepStories extends AbstractStories {
     }
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/AndStep.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/CommentStepStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/CommentStepStories.java
@@ -38,7 +38,7 @@ public class CommentStepStories extends AbstractStories {
     }
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/CommentStep.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/CompositeStepStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/CompositeStepStories.java
@@ -35,7 +35,7 @@ public class CompositeStepStories extends AbstractStories {
     }
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/CompositeStep.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/ExamplesStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/ExamplesStories.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class ExamplesStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/Examples.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/FailInGivenStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/FailInGivenStories.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class FailInGivenStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/FailInGivenStory.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/FailedStepStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/FailedStepStories.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class FailedStepStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/FailedStep.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/GivenStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/GivenStories.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class GivenStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/GivenStory.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/GivenStoryBeforeScenarioStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/GivenStoryBeforeScenarioStories.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class GivenStoryBeforeScenarioStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/GivenStoryBeforeScenario.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/MultipleStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/MultipleStories.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class MultipleStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Arrays.asList(
             "org/jbehavesupport/runner/story/multipleScenario/Scenario01.story",
             "org/jbehavesupport/runner/story/multipleScenario/Scenario01-1.story",

--- a/src/test/java/org/jbehavesupport/runner/story/NestedGivenStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/NestedGivenStories.java
@@ -31,7 +31,7 @@ import org.jbehavesupport.runner.story.steps.TestSteps;
 public class NestedGivenStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/NestedGivenStory.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/PendingStepStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/PendingStepStories.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class PendingStepStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Collections.singletonList(
             "org/jbehavesupport/runner/story/PendingStep.story"
         );

--- a/src/test/java/org/jbehavesupport/runner/story/TwoGivenStoryBeforeScenarioStories.java
+++ b/src/test/java/org/jbehavesupport/runner/story/TwoGivenStoryBeforeScenarioStories.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class TwoGivenStoryBeforeScenarioStories extends AbstractStories {
 
     @Override
-    protected List<String> storyPaths() {
+    public List<String> storyPaths() {
         return Arrays.asList(
             "org/jbehavesupport/runner/story/GivenStoryBeforeScenario.story",
             "org/jbehavesupport/runner/story/SecondGivenStoryBeforeScenario.story"

--- a/src/test/java/org/jbehavesupport/runner/story/steps/TestSteps.java
+++ b/src/test/java/org/jbehavesupport/runner/story/steps/TestSteps.java
@@ -18,6 +18,7 @@
  */
 package org.jbehavesupport.runner.story.steps;
 
+import org.jbehave.core.annotations.BeforeStory;
 import org.jbehave.core.annotations.Composite;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
@@ -31,6 +32,11 @@ import org.slf4j.LoggerFactory;
  * @since 26/08/16
  */
 public class TestSteps {
+
+    @BeforeStory
+    public void before() {
+        logger.info("Before story custom step");
+    }
 
     private static final Logger logger = LoggerFactory.getLogger(TestSteps.class);
 


### PR DESCRIPTION
Currently still supporting JUnit 4 even though JBehave already dropped support. @mbocek do you think we should still keep the support for it or should we also remove it in the future?


Aside from the obvious jbehave API changes, the main noticeable ones:
 * before/after stories now do not get reported all together but as a "normal story". We currently keep the old behavior and just group them together (this still makes sense to me from usability point of view).
 * StoryReporter#beforeStep(Step) hook gets invoked before all steps (including comment, pending, ignorable), previously the hook was invoked only for parameterized steps (but we do not really need/want to use this since we use the other specific methods for comment/pending etc...).

Full jbehave changelog can be found here: https://jbehave.org/reference/latest/migration-paths.html